### PR TITLE
Mythic httpx C2 Profile support for Mythic connector

### DIFF
--- a/docs/Connectors.md
+++ b/docs/Connectors.md
@@ -75,21 +75,26 @@ This tool will connect to the teamserver using the following username format
 |port|Mythic management port|7443|
 |callback_url|redirector url (no ending slash)|https://example.com|
 |callback_port|redirector port|443|
+|httpx_config|absolute path to httpx config file (optional)|/opt/configs/httpx.json|
 
 The Mythic connector works the same as Cobalt Strike connector.
-More specifically, it supports the Apollo payload type using either an HTTP(S) or SMB listener.
+More specifically, it supports the Apollo payload type using either an HTTP(S), SMB, or HTTPX listener.
 The token format is:
 
 `<ARTIFACT>-<PROFILE>`
 
 The first part is the artifact type and will be either "SHELLCODE" or "EXE"
-The second part is the name of the profile. Typically this will be "HTTP" (even for HTTPS).
+The second part is the name of the profile. Typically this will be "HTTP" (even for HTTPS), "SMB", or "HTTPX".
 
 Examples ("mythic" is used to represent the connector name):
 
 Exe using HTTPS callback: `@mythic::EXE-HTTP`
 
+Shellcode using HTTPX callback: `@mythic::SHELLCODE-HTTPX`
+
 *Note: Mythic stores callback connection configurations on a per-payload basis. This needs to be specified in the connector config and not the CLI token. This includes HTTP vs HTTPS and the port. PDCD will use its own default settings for all other payload settings. These can be overridden via environment variables - see [Settings.md](Settings.md).*
+
+*Note: The HTTPX profile requires `httpx_config` to be set in the connector args. This must be an absolute path to the httpx config file, which will be uploaded to Mythic during payload creation.*
 
 ## Remote connector
 

--- a/pdcd/connectors.py
+++ b/pdcd/connectors.py
@@ -57,6 +57,7 @@ class MythicConnector(Connector):
     callback_url: str
     callback_port: str
     user: str
+    config: str = ""
 
     def to_client(self):
         return super().to_client()

--- a/pdcd/connectors.py
+++ b/pdcd/connectors.py
@@ -57,7 +57,7 @@ class MythicConnector(Connector):
     callback_url: str
     callback_port: str
     user: str
-    config: str = ""
+    httpx_config: str = ""
 
     def to_client(self):
         return super().to_client()

--- a/pdcd/external.py
+++ b/pdcd/external.py
@@ -161,6 +161,7 @@ class MythicClient(ClientABC):
         password: str,
         callback_url: str,  # http://example.com
         callback_port: str,
+        config: str = "",
         port: str = "7443",  # management port
         user: str = "neo",
     ):
@@ -170,6 +171,7 @@ class MythicClient(ClientABC):
         self.__user = user
         self.__callback_url = callback_url
         self.__callback_port = callback_port
+        self.__config = config
 
     def resolve_token(self, token: str, file_dir: str, connector_name: str, **kwargs) -> Tuple[str, list]:
         # token format: < ARTIFACT > - < PROFILE >
@@ -216,6 +218,31 @@ class MythicClient(ClientABC):
                 "pipename": global_settings.mythic_smb_pipename,
                 "killdate": "2030-10-12",
                 "encrypted_exchange_check": "T",
+            }
+        elif profile.lower() == "httpx":
+            config_path = pathlib.Path(self.__config)
+            if not config_path.exists() or self.__config == '':
+                raise Exception(f"httpx config file not found: {self.__config}")
+            config_bytes = config_path.read_bytes()
+            file_uuid = asyncio.run(
+                mythic_sdk.register_file(
+                    mythic=mythic,
+                    filename=config_path.name,
+                    contents=config_bytes,
+                )
+            )
+            if not file_uuid:
+                raise Exception(f"Failed to upload httpx config file to Mythic")
+            build_vars = {
+                "AESPSK": "aes256_hmac",
+                "callback_domains": [self.__callback_url + ":" + self.__callback_port],
+                "callback_interval": global_settings.mythic_callback_interval,
+                "callback_jitter": global_settings.mythic_jitter_percent,
+                "domain_rotation": "fail-over",
+                "encrypted_exchange_check": "T",
+                "failover_threshold": "5",
+                "killdate": "2035-10-12",
+                "raw_c2_config": file_uuid,
             }
         else:
             build_vars = {

--- a/pdcd/external.py
+++ b/pdcd/external.py
@@ -7,6 +7,7 @@ import random
 import boto3
 import subprocess
 import json
+import os
 from dataclasses import dataclass, field
 from typing import Optional, TYPE_CHECKING, Tuple
 import mythic.mythic as mythic_sdk
@@ -161,7 +162,7 @@ class MythicClient(ClientABC):
         password: str,
         callback_url: str,  # http://example.com
         callback_port: str,
-        config: str = "",
+        httpx_config: str = "",
         port: str = "7443",  # management port
         user: str = "neo",
     ):
@@ -171,7 +172,9 @@ class MythicClient(ClientABC):
         self.__user = user
         self.__callback_url = callback_url
         self.__callback_port = callback_port
-        self.__config = config
+        if httpx_config and not os.path.isabs(httpx_config):
+            raise ValueError(f"Mythic httpx_config path must be absolute, got: {httpx_config}")
+        self.__httpx_config = httpx_config
 
     def resolve_token(self, token: str, file_dir: str, connector_name: str, **kwargs) -> Tuple[str, list]:
         # token format: < ARTIFACT > - < PROFILE >
@@ -220,8 +223,8 @@ class MythicClient(ClientABC):
                 "encrypted_exchange_check": "T",
             }
         elif profile.lower() == "httpx":
-            config_path = pathlib.Path(self.__config)
-            if not config_path.exists() or self.__config == '':
+            config_path = pathlib.Path(self.__httpx_config)
+            if not config_path.exists() or self.__httpx_config == '':
                 raise Exception(f"httpx config file not found: {self.__config}")
             config_bytes = config_path.read_bytes()
             file_uuid = asyncio.run(


### PR DESCRIPTION
## Summary
- Add support for Mythic's httpx C2 profile, allowing payload generation with custom httpx configurations
- Make the config parameter optional on MythicConnector and MythicClient so existing connector definitions without httpx don't break

## Details
The httpx profile branch in MythicClient.export_shellcode reads a user-provided config file, uploads it to Mythic via register_file, and passes the resulting file UUID as raw_c2_config in the build variables. If the httpx profile is selected without a valid config path, a clear error is raised.

The config field defaults to "" so that connectors files that don't use the httpx profile are not required to specify it.